### PR TITLE
fix: improve readability of privacy policy and terms pages

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -20,7 +20,7 @@ export default function PrivacyPage() {
               })}
             </p>
 
-            <p className="mb-6">
+            <p className="mb-6 text-gray-700">
               SavedTube (&ldquo;we&rdquo;, &ldquo;our&rdquo;, &ldquo;us&rdquo;)
               provides a distraction-free interface to view your own saved
               YouTube playlists.
@@ -30,7 +30,7 @@ export default function PrivacyPage() {
               Information we collect
             </h2>
 
-            <ul className="list-disc pl-6 mb-6 space-y-2">
+            <ul className="list-disc pl-6 mb-6 space-y-2 text-gray-700">
               <li>
                 <strong>Google account information:</strong> your basic profile
                 (name, email, avatar) for sign-in.
@@ -46,7 +46,7 @@ export default function PrivacyPage() {
               How we use this information
             </h2>
 
-            <ul className="list-disc pl-6 mb-6 space-y-2">
+            <ul className="list-disc pl-6 mb-6 space-y-2 text-gray-700">
               <li>To let you log in securely with your Google account.</li>
               <li>
                 To display your playlists/videos inside the SavedTube
@@ -70,7 +70,7 @@ export default function PrivacyPage() {
               Data storage & security
             </h2>
 
-            <ul className="list-disc pl-6 mb-6 space-y-2">
+            <ul className="list-disc pl-6 mb-6 space-y-2 text-gray-700">
               <li>
                 Data is stored in Supabase (Postgres) with row-level security so
                 only you can access your playlists.
@@ -85,7 +85,7 @@ export default function PrivacyPage() {
               Your choices
             </h2>
 
-            <ul className="list-disc pl-6 mb-6 space-y-2">
+            <ul className="list-disc pl-6 mb-6 space-y-2 text-gray-700">
               <li>
                 You can revoke SavedTube&apos;s access at any time in your
                 Google account settings:{' '}
@@ -116,7 +116,7 @@ export default function PrivacyPage() {
               Contact
             </h2>
 
-            <p className="mb-8">
+            <p className="mb-8 text-gray-700">
               If you have any questions about this Privacy Policy, email us at{' '}
               <a
                 href="mailto:support@savedtube.com"

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -23,7 +23,7 @@ export default function TermsPage() {
             <h2 className="text-2xl font-semibold text-gray-900 mt-8 mb-4">
               1. Acceptance of terms
             </h2>
-            <p className="mb-6">
+            <p className="mb-6 text-gray-700">
               By using SavedTube you agree to these Terms of Service. If you do
               not agree, do not use the service.
             </p>
@@ -31,7 +31,7 @@ export default function TermsPage() {
             <h2 className="text-2xl font-semibold text-gray-900 mt-8 mb-4">
               2. Description of service
             </h2>
-            <p className="mb-6">
+            <p className="mb-6 text-gray-700">
               SavedTube provides a distraction-free player for your existing
               YouTube playlists. You must have a valid Google account to use the
               service.
@@ -40,7 +40,7 @@ export default function TermsPage() {
             <h2 className="text-2xl font-semibold text-gray-900 mt-8 mb-4">
               3. User responsibilities
             </h2>
-            <ul className="list-disc pl-6 mb-6 space-y-2">
+            <ul className="list-disc pl-6 mb-6 space-y-2 text-gray-700">
               <li>
                 You are responsible for your use of the service and your YouTube
                 account.
@@ -59,7 +59,7 @@ export default function TermsPage() {
               4. Data access
             </h2>
             <div className="bg-blue-50 border-l-4 border-blue-400 p-4 mb-6">
-              <ul className="list-disc pl-6 space-y-2">
+              <ul className="list-disc pl-6 space-y-2 text-gray-800">
                 <li>
                   SavedTube requires read-only access (youtube.readonly) to your
                   YouTube playlists.
@@ -71,14 +71,14 @@ export default function TermsPage() {
             <h2 className="text-2xl font-semibold text-gray-900 mt-8 mb-4">
               5. Availability and changes
             </h2>
-            <p className="mb-6">
+            <p className="mb-6 text-gray-700">
               We may modify or discontinue SavedTube at any time without notice.
             </p>
 
             <h2 className="text-2xl font-semibold text-gray-900 mt-8 mb-4">
               6. Disclaimer of warranties
             </h2>
-            <p className="mb-6">
+            <p className="mb-6 text-gray-700">
               SavedTube is provided &ldquo;as is&rdquo; without warranties of
               any kind.
             </p>
@@ -86,7 +86,7 @@ export default function TermsPage() {
             <h2 className="text-2xl font-semibold text-gray-900 mt-8 mb-4">
               7. Limitation of liability
             </h2>
-            <p className="mb-6">
+            <p className="mb-6 text-gray-700">
               To the maximum extent permitted by law, SavedTube is not liable
               for any damages resulting from the use of the service.
             </p>
@@ -94,7 +94,7 @@ export default function TermsPage() {
             <h2 className="text-2xl font-semibold text-gray-900 mt-8 mb-4">
               8. Contact
             </h2>
-            <p className="mb-8">
+            <p className="mb-8 text-gray-700">
               For questions about these Terms, contact{' '}
               <a
                 href="mailto:support@savedtube.com"


### PR DESCRIPTION
- Add explicit text-gray-700 color to all paragraphs and bullet points
- Fix text-gray-800 color for blue box content in terms page
- Ensure proper contrast for all text elements
- Resolve white-on-white readability issues in both pages