### PR TITLE
feat: add interval naming and renaming

### DIFF
--- a/src/app/api/vid-intervals/import/route.ts
+++ b/src/app/api/vid-intervals/import/route.ts
@@ -190,6 +190,7 @@ export async function POST(request: NextRequest) {
       id: item.id,
       userId: item.user_id,
       videoId: item.video_id,
+      name: item.name ?? null,
       startTime: item.start_time,
       endTime: item.end_time,
       orderIndex: item.order_index,

--- a/src/app/api/vid-intervals/route.ts
+++ b/src/app/api/vid-intervals/route.ts
@@ -11,6 +11,35 @@ const createIntervalSchema = z.object({
   endTime: z.number().min(0),
 });
 
+const updateIntervalSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().max(100).nullable(),
+});
+
+type VideoIntervalRow = {
+  id: string;
+  user_id: string;
+  video_id: string;
+  name?: string | null;
+  start_time: number;
+  end_time: number;
+  order_index: number;
+  created_at: string;
+  updated_at: string;
+};
+
+const mapInterval = (item: VideoIntervalRow) => ({
+  id: item.id,
+  userId: item.user_id,
+  videoId: item.video_id,
+  name: item.name ?? null,
+  startTime: item.start_time,
+  endTime: item.end_time,
+  orderIndex: item.order_index,
+  createdAt: item.created_at,
+  updatedAt: item.updated_at,
+});
+
 export async function GET(request: NextRequest) {
   try {
     const session = await getServerSession(authOptions);
@@ -47,16 +76,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Map database fields to frontend model
-    const intervals = (data || []).map((item) => ({
-      id: item.id,
-      userId: item.user_id,
-      videoId: item.video_id,
-      startTime: item.start_time,
-      endTime: item.end_time,
-      orderIndex: item.order_index,
-      createdAt: item.created_at,
-      updatedAt: item.updated_at,
-    }));
+    const intervals = (data || []).map(mapInterval);
 
     return NextResponse.json({ intervals });
   } catch (error) {
@@ -132,20 +152,58 @@ export async function POST(request: NextRequest) {
     }
 
     // Map to frontend model
-    const interval = {
-      id: data.id,
-      userId: data.user_id,
-      videoId: data.video_id,
-      startTime: data.start_time,
-      endTime: data.end_time,
-      orderIndex: data.order_index,
-      createdAt: data.created_at,
-      updatedAt: data.updated_at,
-    };
+    const interval = mapInterval(data);
 
     return NextResponse.json({ interval }, { status: 201 });
   } catch (error) {
     console.error('Error in POST /api/vid-intervals:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const validation = updateIntervalSchema.safeParse(body);
+
+    if (!validation.success) {
+      return NextResponse.json(
+        { error: 'Invalid input', details: validation.error.format() },
+        { status: 400 }
+      );
+    }
+
+    const { id, name } = validation.data;
+    const supabase = createServerSupabaseClient();
+
+    const { data, error } = await supabase
+      .from('video_intervals')
+      .update({ name: name?.trim() || null })
+      .eq('id', id)
+      .eq('user_id', session.user.id)
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Error updating interval:', error);
+      return NextResponse.json(
+        { error: 'Failed to update interval' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ interval: mapInterval(data) });
+  } catch (error) {
+    console.error('Error in PATCH /api/vid-intervals:', error);
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }

--- a/src/app/watch/[videoId]/page.tsx
+++ b/src/app/watch/[videoId]/page.tsx
@@ -125,6 +125,25 @@ export default function WatchPage() {
     }
   };
 
+  const handleRenameInterval = async (intervalId: string, name: string) => {
+    try {
+      const response = await fetch('/api/vid-intervals', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: intervalId, name }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to rename interval');
+      }
+
+      await fetchIntervals();
+    } catch (error) {
+      console.error('Error renaming interval:', error);
+      throw error;
+    }
+  };
+
   const handleImportFromYouTube = async (overwrite: boolean) => {
     setIsImportingIntervals(true);
     setImportError(null);
@@ -493,6 +512,7 @@ export default function WatchPage() {
         currentTime={currentTime}
         onAddInterval={handleAddInterval}
         onDeleteInterval={handleDeleteInterval}
+        onRenameInterval={handleRenameInterval}
         onToggleLoop={setLoopEnabled}
         onImportFromYouTube={handleImportFromYouTube}
         isImporting={isImportingIntervals}

--- a/src/components/IntervalManager.tsx
+++ b/src/components/IntervalManager.tsx
@@ -11,6 +11,7 @@ interface IntervalManagerProps {
   currentTime?: number;
   onAddInterval: (startTime: number, endTime: number) => Promise<void>;
   onDeleteInterval: (intervalId: string) => Promise<void>;
+  onRenameInterval: (intervalId: string, name: string) => Promise<void>;
   onToggleLoop: (enabled: boolean) => void;
   onImportFromYouTube?: (overwrite: boolean) => Promise<void>;
   isImporting?: boolean;
@@ -30,6 +31,7 @@ export function IntervalManager({
   currentTime = 0,
   onAddInterval,
   onDeleteInterval,
+  onRenameInterval,
   onToggleLoop,
   onImportFromYouTube,
   isImporting = false,
@@ -45,6 +47,11 @@ export function IntervalManager({
   const [endMinutes, setEndMinutes] = useState('');
   const [endSeconds, setEndSeconds] = useState('');
   const [isAdding, setIsAdding] = useState(false);
+  const [renamingIntervalId, setRenamingIntervalId] = useState<string | null>(
+    null
+  );
+  const [renameValue, setRenameValue] = useState('');
+  const [isRenaming, setIsRenaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const formatTime = (seconds: number): string => {
@@ -120,6 +127,34 @@ export function IntervalManager({
     }
   };
 
+  const getIntervalDisplayName = (interval: VideoInterval, index: number) =>
+    interval.name?.trim() || `interval_${index + 1}`;
+
+  const beginRename = (interval: VideoInterval, index: number) => {
+    setRenamingIntervalId(interval.id);
+    setRenameValue(getIntervalDisplayName(interval, index));
+    setError(null);
+  };
+
+  const cancelRename = () => {
+    setRenamingIntervalId(null);
+    setRenameValue('');
+  };
+
+  const saveRename = async (intervalId: string) => {
+    setIsRenaming(true);
+    setError(null);
+    try {
+      await onRenameInterval(intervalId, renameValue);
+      cancelRename();
+    } catch (err) {
+      setError('Failed to rename interval');
+      console.error(err);
+    } finally {
+      setIsRenaming(false);
+    }
+  };
+
   const handleImport = async () => {
     if (!onImportFromYouTube) return;
 
@@ -138,6 +173,10 @@ export function IntervalManager({
   const totalWatchTime = intervals.reduce(
     (sum, interval) => sum + (interval.endTime - interval.startTime),
     0
+  );
+
+  const sortedIntervals = [...intervals].sort(
+    (a, b) => a.startTime - b.startTime
   );
 
   return (
@@ -246,68 +285,129 @@ export function IntervalManager({
                 </div>
               ) : (
                 <div className="space-y-2">
-                  {intervals
-                    .sort((a, b) => a.orderIndex - b.orderIndex)
-                    .map((interval, index) => (
-                      <div
-                        key={interval.id}
-                        onClick={() => onSelectInterval?.(interval)}
-                        onKeyDown={(event) => {
-                          if (!onSelectInterval) return;
-                          if (event.key === 'Enter' || event.key === ' ') {
-                            event.preventDefault();
-                            onSelectInterval(interval);
-                          }
-                        }}
-                        className={`flex items-center justify-between p-3 rounded-lg transition-colors ${
-                          interval.id === activeIntervalId
-                            ? 'bg-blue-700'
-                            : 'bg-gray-800 hover:bg-gray-750'
-                        } ${onSelectInterval ? 'cursor-pointer' : ''}`}
-                        role={onSelectInterval ? 'button' : undefined}
-                        tabIndex={onSelectInterval ? 0 : undefined}
-                      >
-                        <div className="flex items-center space-x-3">
-                          <span className="text-sm text-gray-400">
-                            #{index + 1}
-                          </span>
-                          <div>
-                            <div className="font-mono text-sm">
-                              {formatTime(interval.startTime)} →{' '}
-                              {formatTime(interval.endTime)}
+                  {sortedIntervals.map((interval, index) => (
+                    <div
+                      key={interval.id}
+                      onClick={() => onSelectInterval?.(interval)}
+                      onKeyDown={(event) => {
+                        if (!onSelectInterval) return;
+                        if (renamingIntervalId === interval.id) return;
+                        if (event.key === 'Enter' || event.key === ' ') {
+                          event.preventDefault();
+                          onSelectInterval(interval);
+                        }
+                      }}
+                      className={`flex items-center justify-between p-3 rounded-lg transition-colors ${
+                        interval.id === activeIntervalId
+                          ? 'bg-blue-700'
+                          : 'bg-gray-800 hover:bg-gray-750'
+                      } ${onSelectInterval ? 'cursor-pointer' : ''}`}
+                      role={onSelectInterval ? 'button' : undefined}
+                      tabIndex={onSelectInterval ? 0 : undefined}
+                    >
+                      <div className="flex min-w-0 flex-1 items-center space-x-3">
+                        <span className="text-sm text-gray-400">
+                          #{index + 1}
+                        </span>
+                        <div className="min-w-0 flex-1">
+                          {renamingIntervalId === interval.id ? (
+                            <div
+                              className="mb-2 flex items-center gap-2"
+                              onClick={(event) => event.stopPropagation()}
+                            >
+                              <input
+                                type="text"
+                                value={renameValue}
+                                onChange={(event) =>
+                                  setRenameValue(event.target.value)
+                                }
+                                onKeyDown={(event) => {
+                                  if (event.key === 'Enter') {
+                                    event.preventDefault();
+                                    saveRename(interval.id);
+                                  }
+                                  if (event.key === 'Escape') {
+                                    event.preventDefault();
+                                    cancelRename();
+                                  }
+                                }}
+                                maxLength={100}
+                                className="min-w-0 flex-1 rounded border border-gray-600 bg-gray-900 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none"
+                                aria-label="Interval name"
+                                autoFocus
+                              />
+                              <button
+                                type="button"
+                                onClick={() => saveRename(interval.id)}
+                                disabled={isRenaming}
+                                className="rounded bg-blue-600 px-2 py-1 text-xs font-medium hover:bg-blue-700 disabled:bg-gray-600"
+                              >
+                                Save
+                              </button>
+                              <button
+                                type="button"
+                                onClick={cancelRename}
+                                disabled={isRenaming}
+                                className="rounded bg-gray-700 px-2 py-1 text-xs font-medium hover:bg-gray-600 disabled:bg-gray-600"
+                              >
+                                Cancel
+                              </button>
                             </div>
-                            <div className="text-xs text-gray-400">
-                              Duration:{' '}
-                              {formatTime(
-                                interval.endTime - interval.startTime
-                              )}
+                          ) : (
+                            <div className="mb-1 flex items-center gap-2">
+                              <div className="truncate text-sm font-medium">
+                                {getIntervalDisplayName(interval, index)}
+                              </div>
+                              <button
+                                type="button"
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  beginRename(interval, index);
+                                }}
+                                className="rounded px-2 py-0.5 text-xs text-blue-300 hover:bg-blue-600 hover:bg-opacity-20"
+                                aria-label={`Rename ${getIntervalDisplayName(
+                                  interval,
+                                  index
+                                )}`}
+                              >
+                                Rename
+                              </button>
                             </div>
+                          )}
+                          <div className="font-mono text-sm">
+                            {formatTime(interval.startTime)} →{' '}
+                            {formatTime(interval.endTime)}
+                          </div>
+                          <div className="text-xs text-gray-400">
+                            Duration:{' '}
+                            {formatTime(interval.endTime - interval.startTime)}
                           </div>
                         </div>
-                        <button
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            handleDelete(interval.id);
-                          }}
-                          className="p-2 hover:bg-red-600 hover:bg-opacity-20 rounded transition-colors"
-                          aria-label="Delete interval"
-                        >
-                          <svg
-                            className="w-5 h-5 text-red-400"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                            />
-                          </svg>
-                        </button>
                       </div>
-                    ))}
+                      <button
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          handleDelete(interval.id);
+                        }}
+                        className="p-2 hover:bg-red-600 hover:bg-opacity-20 rounded transition-colors"
+                        aria-label="Delete interval"
+                      >
+                        <svg
+                          className="w-5 h-5 text-red-400"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  ))}
                 </div>
               )}
             </div>

--- a/src/types/intervals.ts
+++ b/src/types/intervals.ts
@@ -2,6 +2,7 @@ export interface VideoInterval {
   id: string;
   userId: string;
   videoId: string;
+  name?: string | null;
   startTime: number;
   endTime: number;
   orderIndex: number;

--- a/supabase/migrations/20260613_add_interval_names.sql
+++ b/supabase/migrations/20260613_add_interval_names.sql
@@ -1,0 +1,6 @@
+-- Add optional user-editable names for saved video intervals.
+-- Existing rows remain unnamed and the UI derives fallback names from
+-- start-time order (interval_1, interval_2, ...).
+
+ALTER TABLE public.video_intervals
+  ADD COLUMN IF NOT EXISTS name TEXT;


### PR DESCRIPTION
## Summary
- Adds optional names for saved video intervals
- Shows default interval_1, interval_2, interval_3 names based on video start-time order when no custom name exists
- Allows inline interval renaming, with blank names reverting to the default fallback
- Adds a Supabase migration for video_intervals.name and a PATCH API endpoint scoped to the authenticated user

## Test Plan
- npm run type-check
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key SUPABASE_SERVICE_ROLE_KEY=dummy-service-key GOOGLE_CLIENT_ID=dummy-client GOOGLE_CLIENT_SECRET=dummy-...cret NEXTAUTH_SECRET=dummy-...cret NEXTAUTH_URL=http:/...3001 npm run build