### PR TITLE
fix: apply historical Supabase migrations in production

### DIFF
--- a/.github/workflows/migrations-validate.yml
+++ b/.github/workflows/migrations-validate.yml
@@ -64,4 +64,4 @@ jobs:
             exit 1
           fi
 
-          supabase db push --db-url "${SUPABASE_DB_URL}"
+          supabase db push --include-all --db-url "${SUPABASE_DB_URL}"

--- a/supabase/migrations/20250122_create_video_intervals.sql
+++ b/supabase/migrations/20250122_create_video_intervals.sql
@@ -15,17 +15,57 @@ CREATE TABLE IF NOT EXISTS public.video_intervals (
 ALTER TABLE public.video_intervals ENABLE ROW LEVEL SECURITY;
 
 -- Create policies for user-specific data access
-CREATE POLICY "users_can_view_own_intervals" ON public.video_intervals
-    FOR SELECT USING (auth.uid() = user_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'video_intervals'
+          AND policyname = 'users_can_view_own_intervals'
+    ) THEN
+        CREATE POLICY "users_can_view_own_intervals" ON public.video_intervals
+            FOR SELECT USING (auth.uid() = user_id);
+    END IF;
+END $$;
 
-CREATE POLICY "users_can_insert_own_intervals" ON public.video_intervals
-    FOR INSERT WITH CHECK (auth.uid() = user_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'video_intervals'
+          AND policyname = 'users_can_insert_own_intervals'
+    ) THEN
+        CREATE POLICY "users_can_insert_own_intervals" ON public.video_intervals
+            FOR INSERT WITH CHECK (auth.uid() = user_id);
+    END IF;
+END $$;
 
-CREATE POLICY "users_can_update_own_intervals" ON public.video_intervals
-    FOR UPDATE USING (auth.uid() = user_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'video_intervals'
+          AND policyname = 'users_can_update_own_intervals'
+    ) THEN
+        CREATE POLICY "users_can_update_own_intervals" ON public.video_intervals
+            FOR UPDATE USING (auth.uid() = user_id);
+    END IF;
+END $$;
 
-CREATE POLICY "users_can_delete_own_intervals" ON public.video_intervals
-    FOR DELETE USING (auth.uid() = user_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'video_intervals'
+          AND policyname = 'users_can_delete_own_intervals'
+    ) THEN
+        CREATE POLICY "users_can_delete_own_intervals" ON public.video_intervals
+            FOR DELETE USING (auth.uid() = user_id);
+    END IF;
+END $$;
 
 -- Create indexes for performance
 CREATE INDEX IF NOT EXISTS idx_video_intervals_user_id ON public.video_intervals(user_id);
@@ -34,7 +74,8 @@ CREATE INDEX IF NOT EXISTS idx_video_intervals_user_video ON public.video_interv
 CREATE INDEX IF NOT EXISTS idx_video_intervals_order ON public.video_intervals(user_id, video_id, order_index);
 
 -- Add updated_at trigger
-CREATE TRIGGER video_intervals_updated_at 
-    BEFORE UPDATE ON public.video_intervals 
-    FOR EACH ROW 
+DROP TRIGGER IF EXISTS video_intervals_updated_at ON public.video_intervals;
+CREATE TRIGGER video_intervals_updated_at
+    BEFORE UPDATE ON public.video_intervals
+    FOR EACH ROW
     EXECUTE FUNCTION public.handle_updated_at();


### PR DESCRIPTION
## Summary
- Add --include-all to the production Supabase migration deploy step so GitHub Actions can apply migrations that are locally older than the remote migration history.
- Make the historical video_intervals migration idempotent for production by guarding existing RLS policies and recreating the updated_at trigger safely.

## Why
The production migration workflow now reaches Supabase through the session pooler, but Supabase CLI refuses to apply historical local migrations unless --include-all is set. The listed historical migration can touch existing production objects, so it needs to be safe to replay.

## Test Plan
- GitHub Actions: Supabase migration validation on PR
- After merge: rerun/observe production migration workflow on main