### PR TITLE
fix: support existing video interval user id type

### DIFF
--- a/supabase/migrations/20250122_create_video_intervals.sql
+++ b/supabase/migrations/20250122_create_video_intervals.sql
@@ -24,7 +24,7 @@ BEGIN
           AND policyname = 'users_can_view_own_intervals'
     ) THEN
         CREATE POLICY "users_can_view_own_intervals" ON public.video_intervals
-            FOR SELECT USING (auth.uid() = user_id);
+            FOR SELECT USING (auth.uid()::text = user_id::text);
     END IF;
 END $$;
 
@@ -37,7 +37,7 @@ BEGIN
           AND policyname = 'users_can_insert_own_intervals'
     ) THEN
         CREATE POLICY "users_can_insert_own_intervals" ON public.video_intervals
-            FOR INSERT WITH CHECK (auth.uid() = user_id);
+            FOR INSERT WITH CHECK (auth.uid()::text = user_id::text);
     END IF;
 END $$;
 
@@ -50,7 +50,7 @@ BEGIN
           AND policyname = 'users_can_update_own_intervals'
     ) THEN
         CREATE POLICY "users_can_update_own_intervals" ON public.video_intervals
-            FOR UPDATE USING (auth.uid() = user_id);
+            FOR UPDATE USING (auth.uid()::text = user_id::text);
     END IF;
 END $$;
 
@@ -63,7 +63,7 @@ BEGIN
           AND policyname = 'users_can_delete_own_intervals'
     ) THEN
         CREATE POLICY "users_can_delete_own_intervals" ON public.video_intervals
-            FOR DELETE USING (auth.uid() = user_id);
+            FOR DELETE USING (auth.uid()::text = user_id::text);
     END IF;
 END $$;
 


### PR DESCRIPTION
## Summary
- Make the historical video_intervals RLS policies compare auth.uid() and user_id as text.
- This lets the migration replay safely against production, where the existing table may still have user_id as text before later migrations convert/fix it.

## Why
The production migration deploy now reaches Supabase and uses --include-all, but replaying the historical 20250122 migration failed with: operator does not exist: uuid = text.

## Test Plan
- GitHub Actions: Validate migrations on PR
- After merge: observe production migration workflow on main