### PR TITLE
fix: make playlist item edit trigger idempotent

### DIFF
--- a/supabase/migrations/20260214130000_create_playlist_item_edits.sql
+++ b/supabase/migrations/20260214130000_create_playlist_item_edits.sql
@@ -24,6 +24,7 @@ CREATE INDEX IF NOT EXISTS idx_playlist_item_edits_custom_order
 -- Authorization is enforced in API routes with NextAuth session checks
 ALTER TABLE public.playlist_item_edits DISABLE ROW LEVEL SECURITY;
 
+DROP TRIGGER IF EXISTS playlist_item_edits_updated_at ON public.playlist_item_edits;
 CREATE TRIGGER playlist_item_edits_updated_at
   BEFORE UPDATE ON public.playlist_item_edits
   FOR EACH ROW


### PR DESCRIPTION
## Summary
- Drop the playlist_item_edits updated_at trigger before recreating it in the historical migration.

## Why
Production migration replay with --include-all reached the playlist item edits migration but failed because the trigger already exists in production.

## Test Plan
- GitHub Actions: Validate migrations on PR
- After merge: observe production migration workflow on main