### PR TITLE
fix: unify authenticated theme with landing page

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -135,20 +135,20 @@ export default function Dashboard() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-blue-600"></div>
+      <div className="min-h-screen bg-[#080806] text-stone-100 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-24 w-24 border-b-2 border-amber-200"></div>
       </div>
     );
   }
 
   if (!session) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold text-gray-900 mb-4">
+      <div className="min-h-screen bg-[#080806] text-stone-100 flex items-center justify-center px-5">
+        <div className="rounded-[2rem] border border-white/10 bg-[#10100d]/90 p-8 text-center shadow-2xl shadow-black/50">
+          <h1 className="text-2xl font-medium tracking-[-0.03em] text-stone-50 mb-4">
             Access Denied
           </h1>
-          <p className="text-gray-600">
+          <p className="text-stone-400">
             Please sign in to access the dashboard.
           </p>
         </div>
@@ -158,13 +158,15 @@ export default function Dashboard() {
 
   if (error) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold text-red-900 mb-4">Error</h1>
-          <p className="text-red-600 mb-4">{error}</p>
+      <div className="min-h-screen bg-[#080806] text-stone-100 flex items-center justify-center px-5">
+        <div className="rounded-[2rem] border border-red-300/20 bg-[#10100d]/90 p-8 text-center shadow-2xl shadow-black/50">
+          <h1 className="text-2xl font-medium tracking-[-0.03em] text-red-100 mb-4">
+            Error
+          </h1>
+          <p className="text-red-200/80 mb-5">{error}</p>
           <button
             onClick={() => signOut({ callbackUrl: '/' })}
-            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            className="rounded-full bg-stone-100 px-5 py-2.5 text-sm font-medium text-stone-950 transition hover:bg-white"
           >
             Sign out
           </button>
@@ -174,177 +176,189 @@ export default function Dashboard() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <nav className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <div className="flex items-center">
-              <Logo size="lg" variant="default" showText={true} />
-              <span className="text-lg font-medium text-gray-600 ml-4">
-                Dashboard
+    <div className="relative min-h-screen overflow-hidden bg-[#080806] text-stone-100">
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-[520px] bg-[radial-gradient(circle_at_50%_0%,rgba(245,158,11,0.16),transparent_42%),linear-gradient(180deg,rgba(255,255,255,0.045),transparent_55%)]" />
+      <div className="pointer-events-none absolute left-1/2 top-20 h-[1px] w-[78vw] -translate-x-1/2 bg-gradient-to-r from-transparent via-white/20 to-transparent" />
+
+      <nav className="relative z-10 border-b border-white/[0.06] bg-[#080806]/70 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-5 py-5 sm:px-8">
+          <div className="flex items-center gap-4">
+            <Logo size="lg" variant="white" showText={true} />
+            <span className="hidden rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-amber-100/80 sm:inline-flex">
+              Dashboard
+            </span>
+          </div>
+          <div className="flex items-center gap-3 sm:gap-4">
+            <div className="hidden items-center gap-3 sm:flex">
+              {session.user?.image && (
+                <Image
+                  className="h-8 w-8 rounded-full border border-white/10"
+                  src={session.user.image}
+                  alt={session.user.name || 'User'}
+                  width={32}
+                  height={32}
+                />
+              )}
+              <span className="max-w-36 truncate text-sm font-medium text-stone-300">
+                {session.user?.name}
               </span>
             </div>
-            <div className="flex items-center space-x-4">
-              <div className="flex items-center space-x-3">
-                {session.user?.image && (
-                  <Image
-                    className="h-8 w-8 rounded-full"
-                    src={session.user.image}
-                    alt={session.user.name || 'User'}
-                    width={32}
-                    height={32}
-                  />
-                )}
-                <span className="text-sm font-medium text-gray-700">
-                  {session.user?.name}
-                </span>
-              </div>
-              <button
-                onClick={() => signOut({ callbackUrl: '/' })}
-                className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-              >
-                Sign out
-              </button>
-            </div>
+            <button
+              onClick={() => signOut({ callbackUrl: '/' })}
+              className="rounded-full border border-white/10 bg-white/[0.03] px-4 py-2 text-sm font-medium text-stone-200 transition hover:bg-white/[0.06] hover:text-stone-50"
+            >
+              Sign out
+            </button>
           </div>
         </div>
       </nav>
 
-      <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
-        <div className="px-4 py-6 sm:px-0">
-          {/* Search and Visibility Controls */}
-          <div className="mb-6 space-y-4">
-            {/* Search Bar */}
-            <form onSubmit={handleSearch} className="flex gap-2">
-              <input
-                type="text"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder="Search playlists..."
-                className="flex-1 px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white text-gray-900"
-                style={{
-                  WebkitAppearance: 'none',
-                  MozAppearance: 'none',
-                  appearance: 'none',
-                  WebkitTextFillColor: 'rgb(17, 24, 39)',
-                  WebkitBoxShadow: '0 0 0px 1000px white inset',
-                }}
-              />
-              <button
-                type="submit"
-                disabled={isLoadingPlaylists}
-                className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50"
-              >
-                {isLoadingPlaylists ? 'Searching...' : 'Search'}
-              </button>
-            </form>
+      <main className="relative z-10 mx-auto max-w-7xl px-5 py-10 sm:px-8 lg:py-14">
+        <section className="mb-9 max-w-3xl">
+          <p className="font-mono text-xs uppercase tracking-[0.28em] text-amber-100/70">
+            YouTube practice library
+          </p>
+          <h1 className="mt-4 text-4xl font-medium leading-[0.95] tracking-[-0.055em] text-stone-50 sm:text-5xl">
+            Choose a playlist and turn it into focused reps.
+          </h1>
+          <p className="mt-5 max-w-2xl text-lg leading-8 text-stone-400">
+            Your imported YouTube playlists now live in the same calm practice
+            room as the landing page.
+          </p>
+        </section>
 
-            {/* Visibility Toggle */}
-            <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-4">
-                <button
-                  onClick={() => setShowHidden(false)}
-                  className={`px-4 py-2 rounded-md text-sm font-medium ${
-                    !showHidden
-                      ? 'bg-blue-600 text-white'
-                      : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-                  }`}
-                >
-                  Visible Playlists (
-                  {
-                    playlists.filter((p) => !hiddenPlaylistIds.includes(p.id))
-                      .length
-                  }
-                  )
-                </button>
-                <button
-                  onClick={() => setShowHidden(true)}
-                  className={`px-4 py-2 rounded-md text-sm font-medium ${
-                    showHidden
-                      ? 'bg-blue-600 text-white'
-                      : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-                  }`}
-                >
-                  Hidden Playlists ({hiddenPlaylistIds.length})
-                </button>
-              </div>
-            </div>
+        {/* Search and Visibility Controls */}
+        <div className="mb-8 rounded-[1.5rem] border border-white/10 bg-[#10100d]/90 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] backdrop-blur sm:p-5">
+          {/* Search Bar */}
+          <form
+            onSubmit={handleSearch}
+            className="flex flex-col gap-3 sm:flex-row"
+          >
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search playlists..."
+              className="flex-1 rounded-full border border-white/10 bg-white/[0.035] px-5 py-3 text-sm text-stone-100 placeholder:text-stone-500 outline-none transition focus:border-amber-200/40 focus:bg-white/[0.055]"
+              style={{
+                WebkitAppearance: 'none',
+                MozAppearance: 'none',
+                appearance: 'none',
+              }}
+            />
+            <button
+              type="submit"
+              disabled={isLoadingPlaylists}
+              className="rounded-full bg-stone-100 px-6 py-3 text-sm font-medium text-stone-950 transition hover:bg-white disabled:cursor-wait disabled:opacity-60"
+            >
+              {isLoadingPlaylists ? 'Searching...' : 'Search'}
+            </button>
+          </form>
+
+          {/* Visibility Toggle */}
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <button
+              onClick={() => setShowHidden(false)}
+              className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                !showHidden
+                  ? 'bg-amber-300/15 text-amber-100 ring-1 ring-amber-200/25'
+                  : 'bg-white/[0.035] text-stone-400 ring-1 ring-white/10 hover:bg-white/[0.06] hover:text-stone-100'
+              }`}
+            >
+              Visible Playlists (
+              {
+                playlists.filter((p) => !hiddenPlaylistIds.includes(p.id))
+                  .length
+              }
+              )
+            </button>
+            <button
+              onClick={() => setShowHidden(true)}
+              className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                showHidden
+                  ? 'bg-amber-300/15 text-amber-100 ring-1 ring-amber-200/25'
+                  : 'bg-white/[0.035] text-stone-400 ring-1 ring-white/10 hover:bg-white/[0.06] hover:text-stone-100'
+              }`}
+            >
+              Hidden Playlists ({hiddenPlaylistIds.length})
+            </button>
           </div>
-
-          {/* Playlists Grid */}
-          {isLoadingPlaylists ? (
-            <div className="flex justify-center py-12">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
-            </div>
-          ) : visiblePlaylists.length > 0 ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {visiblePlaylists.map((playlist) => {
-                const isHidden = hiddenPlaylistIds.includes(playlist.id);
-                return (
-                  <div
-                    key={playlist.id}
-                    className={`bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 overflow-hidden ${
-                      isHidden ? 'opacity-75' : ''
-                    }`}
-                  >
-                    <Link href={`/p/${playlist.id}`}>
-                      <div className="aspect-video relative">
-                        <Image
-                          src={playlist.snippet.thumbnails.medium.url}
-                          alt={playlist.snippet.title}
-                          fill
-                          className="object-cover"
-                        />
-                      </div>
-                      <div className="p-4">
-                        <h3 className="font-semibold text-gray-900 line-clamp-2 mb-2">
-                          {playlist.snippet.title}
-                        </h3>
-                        <p className="text-sm text-gray-600 mb-2">
-                          {playlist.snippet.channelTitle}
-                        </p>
-                        <p className="text-sm text-gray-500">
-                          {playlist.contentDetails.itemCount} videos
-                        </p>
-                      </div>
-                    </Link>
-
-                    {/* Hide/Show Toggle Button */}
-                    <div className="px-4 pb-4">
-                      <button
-                        onClick={(e) => {
-                          e.preventDefault();
-                          togglePlaylistVisibility(playlist.id, isHidden);
-                        }}
-                        className={`w-full px-3 py-2 text-sm font-medium rounded-md transition-colors ${
-                          isHidden
-                            ? 'bg-green-100 text-green-700 hover:bg-green-200'
-                            : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                        }`}
-                        title={isHidden ? 'Show playlist' : 'Hide playlist'}
-                      >
-                        {isHidden ? 'Show Playlist' : 'Hide Playlist'}
-                      </button>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          ) : (
-            <div className="text-center py-12">
-              <h3 className="text-lg font-medium text-gray-900 mb-2">
-                {showHidden ? 'No hidden playlists' : 'No playlists found'}
-              </h3>
-              <p className="text-gray-600">
-                {searchQuery
-                  ? 'Try a different search term.'
-                  : showHidden
-                    ? "You haven't hidden any playlists yet."
-                    : "You don't have any playlists yet."}
-              </p>
-            </div>
-          )}
         </div>
+
+        {/* Playlists Grid */}
+        {isLoadingPlaylists ? (
+          <div className="flex justify-center py-12">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-amber-200"></div>
+          </div>
+        ) : visiblePlaylists.length > 0 ? (
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {visiblePlaylists.map((playlist) => {
+              const isHidden = hiddenPlaylistIds.includes(playlist.id);
+              return (
+                <div
+                  key={playlist.id}
+                  className={`group overflow-hidden rounded-[1.5rem] border border-white/10 bg-[#10100d]/90 shadow-2xl shadow-black/30 transition duration-200 hover:-translate-y-0.5 hover:border-amber-200/25 ${
+                    isHidden ? 'opacity-60' : ''
+                  }`}
+                >
+                  <Link href={`/p/${playlist.id}`}>
+                    <div className="relative aspect-video bg-[linear-gradient(135deg,#151512,#0a0a08)]">
+                      <Image
+                        src={playlist.snippet.thumbnails.medium.url}
+                        alt={playlist.snippet.title}
+                        fill
+                        className="object-cover opacity-85 transition duration-200 group-hover:opacity-100"
+                      />
+                      <div className="absolute inset-0 bg-gradient-to-t from-black/55 via-transparent to-transparent" />
+                    </div>
+                    <div className="p-5">
+                      <h3 className="line-clamp-2 font-medium tracking-[-0.02em] text-stone-100">
+                        {playlist.snippet.title}
+                      </h3>
+                      <p className="mt-3 text-sm text-stone-400">
+                        {playlist.snippet.channelTitle}
+                      </p>
+                      <p className="mt-2 font-mono text-xs uppercase tracking-[0.18em] text-amber-100/60">
+                        {playlist.contentDetails.itemCount} videos
+                      </p>
+                    </div>
+                  </Link>
+
+                  {/* Hide/Show Toggle Button */}
+                  <div className="px-5 pb-5">
+                    <button
+                      onClick={(e) => {
+                        e.preventDefault();
+                        togglePlaylistVisibility(playlist.id, isHidden);
+                      }}
+                      className={`w-full rounded-full border px-4 py-2.5 text-sm font-medium transition ${
+                        isHidden
+                          ? 'border-emerald-200/25 bg-emerald-300/10 text-emerald-100 hover:bg-emerald-300/15'
+                          : 'border-white/10 bg-white/[0.035] text-stone-300 hover:bg-white/[0.06] hover:text-stone-100'
+                      }`}
+                      title={isHidden ? 'Show playlist' : 'Hide playlist'}
+                    >
+                      {isHidden ? 'Show Playlist' : 'Hide Playlist'}
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="rounded-[1.5rem] border border-white/10 bg-[#10100d]/90 px-6 py-14 text-center">
+            <h3 className="text-lg font-medium text-stone-100 mb-2">
+              {showHidden ? 'No hidden playlists' : 'No playlists found'}
+            </h3>
+            <p className="text-stone-400">
+              {searchQuery
+                ? 'Try a different search term.'
+                : showHidden
+                  ? "You haven't hidden any playlists yet."
+                  : "You don't have any playlists yet."}
+            </p>
+          </div>
+        )}
       </main>
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 :root {
   --background: #ffffff;
@@ -25,23 +25,17 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
-/* Override browser autofill styles */
+/* Keep browser autofill aligned with the dark product surface. */
 input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus,
 input:-webkit-autofill:active,
-input[type="text"]:-webkit-autofill,
-input[type="email"]:-webkit-autofill,
-input[type="search"]:-webkit-autofill {
-  -webkit-box-shadow: 0 0 0 30px white inset !important;
-  -webkit-text-fill-color: rgb(17, 24, 39) !important;
+input[type='text']:-webkit-autofill,
+input[type='email']:-webkit-autofill,
+input[type='search']:-webkit-autofill,
+input[type='url']:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 30px #10100d inset !important;
+  -webkit-text-fill-color: rgb(245, 245, 244) !important;
+  caret-color: rgb(245, 245, 244);
   transition: background-color 5000s ease-in-out 0s;
-}
-
-/* Ensure input fields have proper styling */
-input[type="text"],
-input[type="email"],
-input[type="search"] {
-  background-color: white !important;
-  color: rgb(17, 24, 39) !important;
 }

--- a/src/app/p/[playlistId]/page.tsx
+++ b/src/app/p/[playlistId]/page.tsx
@@ -181,7 +181,10 @@ export default function PlaylistPage() {
 
     const previousItems = items;
     const reordered = [...items];
-    [reordered[index], reordered[target]] = [reordered[target], reordered[index]];
+    [reordered[index], reordered[target]] = [
+      reordered[target],
+      reordered[index],
+    ];
     setItems(reordered);
     setIsApplyingEdit(true);
 
@@ -284,21 +287,23 @@ export default function PlaylistPage() {
 
   if (status === 'loading' || isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-blue-600"></div>
+      <div className="min-h-screen bg-[#080806] text-stone-100 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-24 w-24 border-b-2 border-amber-200"></div>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold text-red-900 mb-4">Error</h1>
-          <p className="text-red-600 mb-4">{error}</p>
+      <div className="min-h-screen bg-[#080806] text-stone-100 flex items-center justify-center px-5">
+        <div className="rounded-[2rem] border border-red-300/20 bg-[#10100d]/90 p-8 text-center shadow-2xl shadow-black/50">
+          <h1 className="text-2xl font-medium tracking-[-0.03em] text-red-100 mb-4">
+            Error
+          </h1>
+          <p className="text-red-200/80 mb-5">{error}</p>
           <Link
             href="/dashboard"
-            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            className="rounded-full bg-stone-100 px-5 py-2.5 text-sm font-medium text-stone-950 transition hover:bg-white"
           >
             Back to Dashboard
           </Link>
@@ -308,236 +313,253 @@ export default function PlaylistPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <nav className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <div className="flex items-center">
-              <Link
-                href="/dashboard"
-                className="text-gray-500 hover:text-gray-700 mr-4"
-              >
-                ← Back to Playlists
-              </Link>
-              <Logo size="lg" variant="default" showText={true} />
-              <span className="text-lg font-medium text-gray-600 ml-4">
-                Playlist
-              </span>
-            </div>
-            <div className="flex items-center space-x-4">
-              <div className="flex items-center space-x-3">
-                {session?.user?.image && (
-                  <Image
-                    className="h-8 w-8 rounded-full"
-                    src={session.user.image}
-                    alt={session.user.name || 'User'}
-                    width={32}
-                    height={32}
-                  />
-                )}
-                <span className="text-sm font-medium text-gray-700">
-                  {session?.user?.name}
-                </span>
-              </div>
-            </div>
+    <div className="relative min-h-screen overflow-hidden bg-[#080806] text-stone-100">
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-[520px] bg-[radial-gradient(circle_at_50%_0%,rgba(245,158,11,0.16),transparent_42%),linear-gradient(180deg,rgba(255,255,255,0.045),transparent_55%)]" />
+      <div className="pointer-events-none absolute left-1/2 top-20 h-[1px] w-[78vw] -translate-x-1/2 bg-gradient-to-r from-transparent via-white/20 to-transparent" />
+
+      <nav className="relative z-10 border-b border-white/[0.06] bg-[#080806]/70 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-5 py-5 sm:px-8">
+          <div className="flex items-center gap-4">
+            <Link
+              href="/dashboard"
+              className="hidden rounded-full border border-white/10 bg-white/[0.03] px-3 py-2 text-sm font-medium text-stone-300 transition hover:bg-white/[0.06] hover:text-stone-50 sm:inline-flex"
+            >
+              ← Playlists
+            </Link>
+            <Logo size="lg" variant="white" showText={true} />
+            <span className="hidden rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-amber-100/80 lg:inline-flex">
+              Playlist
+            </span>
+          </div>
+          <div className="flex items-center gap-3">
+            {session?.user?.image && (
+              <Image
+                className="h-8 w-8 rounded-full border border-white/10"
+                src={session.user.image}
+                alt={session.user.name || 'User'}
+                width={32}
+                height={32}
+              />
+            )}
+            <span className="hidden max-w-36 truncate text-sm font-medium text-stone-300 sm:inline">
+              {session?.user?.name}
+            </span>
           </div>
         </div>
       </nav>
 
-      <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
-        <div className="px-4 py-6 sm:px-0">
-          <div className="bg-white rounded-lg shadow-md p-4 mb-6 space-y-4">
-            <div className="flex flex-col sm:flex-row gap-4 sm:items-center sm:justify-between">
-              <div className="flex items-center gap-2">
-                <label
-                  htmlFor="sort-mode"
-                  className="text-sm font-medium text-gray-700"
-                >
-                  Sort
-                </label>
-                <select
-                  id="sort-mode"
-                  value={sortMode}
-                  onChange={(event) => setSortMode(event.target.value as SortMode)}
-                  className="px-3 py-2 border border-gray-300 rounded-md text-sm bg-white text-gray-900"
-                >
-                  <option value="custom">Custom order</option>
-                  <option value="date_desc">Date (newest first)</option>
-                  <option value="date_asc">Date (oldest first)</option>
-                  <option value="alpha_asc">Alphabetical (A-Z)</option>
-                  <option value="alpha_desc">Alphabetical (Z-A)</option>
-                </select>
-              </div>
-              <p className="text-xs text-gray-500">
-                Total videos shown: {items.length}
-              </p>
-            </div>
+      <main className="relative z-10 mx-auto max-w-7xl px-5 py-10 sm:px-8 lg:py-14">
+        <section className="mb-9 max-w-3xl">
+          <p className="font-mono text-xs uppercase tracking-[0.28em] text-amber-100/70">
+            Playlist practice room
+          </p>
+          <h1 className="mt-4 text-4xl font-medium leading-[0.95] tracking-[-0.055em] text-stone-50 sm:text-5xl">
+            Arrange the lesson path before you start looping.
+          </h1>
+          <p className="mt-5 max-w-2xl text-lg leading-8 text-stone-400">
+            Sort, add, remove, and open videos without leaving the warm studio
+            language from the landing page.
+          </p>
+        </section>
 
-            <form onSubmit={addVideoByUrl} className="flex flex-col sm:flex-row gap-2">
-              <input
-                type="url"
-                value={videoUrl}
-                onChange={(event) => setVideoUrl(event.target.value)}
-                placeholder="Add video by YouTube URL"
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-md bg-white text-gray-900"
-                required
-              />
-              <button
-                type="submit"
-                disabled={isApplyingEdit}
-                className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
+        <div className="mb-8 space-y-4 rounded-[1.5rem] border border-white/10 bg-[#10100d]/90 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] backdrop-blur sm:p-5">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-wrap items-center gap-3">
+              <label
+                htmlFor="sort-mode"
+                className="text-sm font-medium text-stone-300"
               >
-                Add video
-              </button>
-            </form>
-
-            {editError && (
-              <div className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-md px-3 py-2">
-                {editError}
-              </div>
-            )}
-
-            {editMessage && (
-              <div className="text-sm text-green-700 bg-green-50 border border-green-200 rounded-md px-3 py-2">
-                {editMessage}
-              </div>
-            )}
+                Sort
+              </label>
+              <select
+                id="sort-mode"
+                value={sortMode}
+                onChange={(event) =>
+                  setSortMode(event.target.value as SortMode)
+                }
+                className="rounded-full border border-white/10 bg-white/[0.035] px-4 py-2 text-sm text-stone-100 outline-none transition focus:border-amber-200/40 focus:bg-white/[0.055]"
+              >
+                <option value="custom">Custom order</option>
+                <option value="date_desc">Date (newest first)</option>
+                <option value="date_asc">Date (oldest first)</option>
+                <option value="alpha_asc">Alphabetical (A-Z)</option>
+                <option value="alpha_desc">Alphabetical (Z-A)</option>
+              </select>
+            </div>
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-amber-100/60">
+              Total videos shown: {items.length}
+            </p>
           </div>
 
-          {items.length > 0 ? (
-            <div className="space-y-4">
-              {items.map((item, index) => {
-                const videoId = item.contentDetails.videoId;
-                const watched =
-                  progress.find((p) => p.video_id === videoId)?.watched || false;
+          <form
+            onSubmit={addVideoByUrl}
+            className="flex flex-col gap-3 sm:flex-row"
+          >
+            <input
+              type="url"
+              value={videoUrl}
+              onChange={(event) => setVideoUrl(event.target.value)}
+              placeholder="Add video by YouTube URL"
+              className="flex-1 rounded-full border border-white/10 bg-white/[0.035] px-5 py-3 text-sm text-stone-100 placeholder:text-stone-500 outline-none transition focus:border-amber-200/40 focus:bg-white/[0.055]"
+              required
+            />
+            <button
+              type="submit"
+              disabled={isApplyingEdit}
+              className="rounded-full bg-stone-100 px-6 py-3 text-sm font-medium text-stone-950 transition hover:bg-white disabled:cursor-wait disabled:opacity-60"
+            >
+              Add video
+            </button>
+          </form>
 
-                return (
-                  <div
-                    key={item.id}
-                    className={`bg-white rounded-lg shadow-md p-4 flex items-center space-x-4 ${
-                      watched ? 'opacity-75' : ''
-                    }`}
-                  >
-                    <div className="flex-shrink-0">
-                      <div className="relative w-32 h-20">
-                        <Image
-                          src={
-                            item.snippet.thumbnails?.medium?.url ||
-                            item.snippet.thumbnails?.default?.url ||
-                            'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIwIiBoZWlnaHQ9IjE4MCIgdmlld0JveD0iMCAwIDMyMCAxODAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiBmaWxsPSIjRjNGNEY2Ii8+CjxwYXRoIGQ9Ik0xNjAgOTBDMTQzLjQzMSA5MCAxMzAgMTAzLjQzMSAxMzAgMTIwQzEzMCAxMzYuNTY5IDE0My40MzEgMTUwIDE2MCAxNTBDMTc2LjU2OSAxNTAgMTkwIDEzNi41NjkgMTkwIDEyMEMxOTAgMTAzLjQzMSAxNzYuNTY5IDkwIDE2MCA5MFoiIGZpbGw9IiM5Q0EzQUYiLz4KPHBhdGggZD0iTTE0MCAxMzBMMTcwIDEyMEwxNDAgMTEwVjEzMFoiIGZpbGw9IndoaXRlIi8+Cjwvc3ZnPgo='
-                          }
-                          alt={item.snippet.title}
-                          fill
-                          className="object-cover rounded"
-                        />
-                      </div>
-                    </div>
-
-                    <div className="flex-1 min-w-0">
-                      <h3 className="text-lg font-medium text-gray-900 truncate">
-                        {item.snippet.title}
-                      </h3>
-                      <p className="text-sm text-gray-600">
-                        {item.snippet.channelTitle || 'Unknown Channel'}
-                      </p>
-                      <p className="text-sm text-gray-500">
-                        {item.snippet.publishedAt
-                          ? new Date(item.snippet.publishedAt).toLocaleDateString()
-                          : 'Unknown Date'}
-                      </p>
-                    </div>
-
-                    <div className="flex items-center space-x-2">
-                      {sortMode === 'custom' && (
-                        <>
-                          <button
-                            onClick={() => moveItem(index, -1)}
-                            disabled={index === 0 || isApplyingEdit}
-                            className="p-2 rounded-full bg-gray-100 text-gray-600 hover:bg-gray-200 disabled:opacity-40"
-                            title="Move up"
-                          >
-                            ↑
-                          </button>
-                          <button
-                            onClick={() => moveItem(index, 1)}
-                            disabled={index === items.length - 1 || isApplyingEdit}
-                            className="p-2 rounded-full bg-gray-100 text-gray-600 hover:bg-gray-200 disabled:opacity-40"
-                            title="Move down"
-                          >
-                            ↓
-                          </button>
-                        </>
-                      )}
-
-                      <button
-                        onClick={() => toggleWatched(videoId, watched)}
-                        className={`p-2 rounded-full ${
-                          watched
-                            ? 'bg-green-100 text-green-600 hover:bg-green-200'
-                            : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-                        }`}
-                        title={watched ? 'Mark as unwatched' : 'Mark as watched'}
-                      >
-                        {watched ? (
-                          <svg
-                            className="w-5 h-5"
-                            fill="currentColor"
-                            viewBox="0 0 20 20"
-                          >
-                            <path
-                              fillRule="evenodd"
-                              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                              clipRule="evenodd"
-                            />
-                          </svg>
-                        ) : (
-                          <svg
-                            className="w-5 h-5"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M5 13l4 4L19 7"
-                            />
-                          </svg>
-                        )}
-                      </button>
-
-                      <button
-                        onClick={() => removeVideo(videoId)}
-                        disabled={isApplyingEdit}
-                        className="px-3 py-2 text-sm rounded-md bg-red-50 text-red-700 hover:bg-red-100 disabled:opacity-50"
-                        title="Remove from this playlist view"
-                      >
-                        Remove
-                      </button>
-
-                      <Link
-                        href={`/watch/${videoId}?playlistId=${playlistId}`}
-                        className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-                      >
-                        Watch
-                      </Link>
-                    </div>
-                  </div>
-                );
-              })}
+          {editError && (
+            <div className="rounded-2xl border border-red-300/20 bg-red-300/10 px-4 py-3 text-sm text-red-100">
+              {editError}
             </div>
-          ) : (
-            <div className="text-center py-12">
-              <h3 className="text-lg font-medium text-gray-900 mb-2">
-                No videos found
-              </h3>
-              <p className="text-gray-600">
-                This playlist appears to be empty or all items were removed.
-              </p>
+          )}
+
+          {editMessage && (
+            <div className="rounded-2xl border border-emerald-300/20 bg-emerald-300/10 px-4 py-3 text-sm text-emerald-100">
+              {editMessage}
             </div>
           )}
         </div>
+
+        {items.length > 0 ? (
+          <div className="space-y-4">
+            {items.map((item, index) => {
+              const videoId = item.contentDetails.videoId;
+              const watched =
+                progress.find((p) => p.video_id === videoId)?.watched || false;
+
+              return (
+                <div
+                  key={item.id}
+                  className={`grid gap-4 rounded-[1.5rem] border border-white/10 bg-[#10100d]/90 p-4 shadow-2xl shadow-black/20 transition duration-200 hover:border-amber-200/25 sm:grid-cols-[8rem_1fr_auto] sm:items-center ${
+                    watched ? 'opacity-60' : ''
+                  }`}
+                >
+                  <div className="relative aspect-video overflow-hidden rounded-2xl bg-[linear-gradient(135deg,#151512,#0a0a08)] sm:h-20 sm:w-32">
+                    <Image
+                      src={
+                        item.snippet.thumbnails?.medium?.url ||
+                        item.snippet.thumbnails?.default?.url ||
+                        'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIwIiBoZWlnaHQ9IjE4MCIgdmlld0JveD0iMCAwIDMyMCAxODAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZyI+CjxyZWN0IHdpZHRoPSIzMjAiIGhlaWdodD0iMTgwIiBmaWxsPSIjRjNGNEY2Ii8+CjxwYXRoIGQ9Ik0xNjAgOTBDMTQzLjQzMSA5MCAxMzAgMTAzLjQzMSAxMzAgMTIwQzEzMCAxMzYuNTY5IDE0My40MzEgMTUwIDE2MCAxNTBDMTc2LjU2OSAxNTAgMTkwIDEzNi41NjkgMTkwIDEyMEMxOTAgMTAzLjQzMSAxNzYuNTY5IDkwIDE2MCA5MFoiIGZpbGw9IiM5Q0EzQUYiLz4KPHBhdGggZD0iTTE0MCAxMzBMMTcwIDEyMEwxNDAgMTEwVjEzMFoiIGZpbGw9IndoaXRlIi8+Cjwvc3ZnPgo='
+                      }
+                      alt={item.snippet.title}
+                      fill
+                      className="object-cover opacity-85"
+                    />
+                  </div>
+
+                  <div className="min-w-0">
+                    <h3 className="truncate text-lg font-medium tracking-[-0.02em] text-stone-100">
+                      {item.snippet.title}
+                    </h3>
+                    <p className="mt-1 text-sm text-stone-400">
+                      {item.snippet.channelTitle || 'Unknown Channel'}
+                    </p>
+                    <p className="mt-2 font-mono text-xs uppercase tracking-[0.18em] text-stone-500">
+                      {item.snippet.publishedAt
+                        ? new Date(
+                            item.snippet.publishedAt
+                          ).toLocaleDateString()
+                        : 'Unknown Date'}
+                    </p>
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+                    {sortMode === 'custom' && (
+                      <>
+                        <button
+                          onClick={() => moveItem(index, -1)}
+                          disabled={index === 0 || isApplyingEdit}
+                          className="rounded-full border border-white/10 bg-white/[0.035] px-3 py-2 text-stone-300 transition hover:bg-white/[0.06] disabled:cursor-not-allowed disabled:opacity-40"
+                          title="Move up"
+                        >
+                          ↑
+                        </button>
+                        <button
+                          onClick={() => moveItem(index, 1)}
+                          disabled={
+                            index === items.length - 1 || isApplyingEdit
+                          }
+                          className="rounded-full border border-white/10 bg-white/[0.035] px-3 py-2 text-stone-300 transition hover:bg-white/[0.06] disabled:cursor-not-allowed disabled:opacity-40"
+                          title="Move down"
+                        >
+                          ↓
+                        </button>
+                      </>
+                    )}
+
+                    <button
+                      onClick={() => toggleWatched(videoId, watched)}
+                      className={`rounded-full border px-3 py-2 transition ${
+                        watched
+                          ? 'border-emerald-200/25 bg-emerald-300/10 text-emerald-100 hover:bg-emerald-300/15'
+                          : 'border-white/10 bg-white/[0.035] text-stone-300 hover:bg-white/[0.06]'
+                      }`}
+                      title={watched ? 'Mark as unwatched' : 'Mark as watched'}
+                    >
+                      {watched ? (
+                        <svg
+                          className="w-5 h-5"
+                          fill="currentColor"
+                          viewBox="0 0 20 20"
+                        >
+                          <path
+                            fillRule="evenodd"
+                            d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                            clipRule="evenodd"
+                          />
+                        </svg>
+                      ) : (
+                        <svg
+                          className="w-5 h-5"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M5 13l4 4L19 7"
+                          />
+                        </svg>
+                      )}
+                    </button>
+
+                    <button
+                      onClick={() => removeVideo(videoId)}
+                      disabled={isApplyingEdit}
+                      className="rounded-full border border-red-300/20 bg-red-300/10 px-4 py-2 text-sm font-medium text-red-100 transition hover:bg-red-300/15 disabled:opacity-50"
+                      title="Remove from this playlist view"
+                    >
+                      Remove
+                    </button>
+
+                    <Link
+                      href={`/watch/${videoId}?playlistId=${playlistId}`}
+                      className="rounded-full bg-stone-100 px-5 py-2 text-sm font-medium text-stone-950 transition hover:bg-white"
+                    >
+                      Watch
+                    </Link>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="rounded-[1.5rem] border border-white/10 bg-[#10100d]/90 px-6 py-14 text-center">
+            <h3 className="text-lg font-medium text-stone-100 mb-2">
+              No videos found
+            </h3>
+            <p className="text-stone-400">
+              This playlist appears to be empty or all items were removed.
+            </p>
+          </div>
+        )}
       </main>
     </div>
   );

--- a/src/app/watch/[videoId]/page.tsx
+++ b/src/app/watch/[videoId]/page.tsx
@@ -372,21 +372,23 @@ export default function WatchPage() {
 
   if (status === 'loading' || isLoading) {
     return (
-      <div className="min-h-screen bg-black flex items-center justify-center">
-        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-white"></div>
+      <div className="min-h-screen bg-[#080806] text-stone-100 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-24 w-24 border-b-2 border-amber-200"></div>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="min-h-screen bg-black flex items-center justify-center">
-        <div className="text-center text-white">
-          <h1 className="text-2xl font-bold mb-4">Error</h1>
-          <p className="mb-4">{error}</p>
+      <div className="min-h-screen bg-[#080806] text-stone-100 flex items-center justify-center px-5">
+        <div className="rounded-[2rem] border border-red-300/20 bg-[#10100d]/90 p-8 text-center shadow-2xl shadow-black/50">
+          <h1 className="text-2xl font-medium tracking-[-0.03em] text-red-100 mb-4">
+            Error
+          </h1>
+          <p className="text-red-200/80 mb-5">{error}</p>
           <Link
             href="/dashboard"
-            className="px-4 py-2 text-sm font-medium text-black bg-white rounded-md hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white"
+            className="rounded-full bg-stone-100 px-5 py-2.5 text-sm font-medium text-stone-950 transition hover:bg-white"
           >
             Back to Dashboard
           </Link>
@@ -400,31 +402,34 @@ export default function WatchPage() {
   const hasPrevious = currentIndex > 0;
 
   return (
-    <div className="min-h-screen bg-black">
+    <div className="relative min-h-screen overflow-hidden bg-[#080806] text-stone-100">
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-[420px] bg-[radial-gradient(circle_at_50%_0%,rgba(245,158,11,0.14),transparent_42%),linear-gradient(180deg,rgba(255,255,255,0.045),transparent_55%)]" />
+      <div className="pointer-events-none absolute left-1/2 top-20 h-[1px] w-[78vw] -translate-x-1/2 bg-gradient-to-r from-transparent via-white/20 to-transparent" />
+
       {/* Minimal header */}
-      <div className="absolute top-0 left-0 right-0 z-10 bg-black bg-opacity-50 backdrop-blur-sm">
-        <div className="flex items-center justify-between p-4">
-          <div className="flex items-center space-x-4">
+      <div className="absolute left-0 right-0 top-0 z-10 border-b border-white/[0.06] bg-[#080806]/70 backdrop-blur-xl">
+        <div className="flex items-center justify-between gap-4 px-5 py-4 sm:px-8">
+          <div className="flex min-w-0 items-center gap-4">
             <Link
               href={`/p/${playlistId}`}
-              className="text-white hover:text-gray-300 transition-colors"
+              className="rounded-full border border-white/10 bg-white/[0.03] px-3 py-2 text-sm font-medium text-stone-300 transition hover:bg-white/[0.06] hover:text-stone-50"
             >
-              ← Back to Playlist
+              ← Playlist
             </Link>
             {currentItem && (
-              <div className="text-white">
-                <h1 className="text-lg font-medium truncate max-w-md">
+              <div className="min-w-0">
+                <h1 className="max-w-[42vw] truncate text-base font-medium tracking-[-0.02em] text-stone-50 sm:text-lg">
                   {currentItem.snippet.title}
                 </h1>
-                <p className="text-sm text-gray-300">
+                <p className="truncate text-sm text-stone-400">
                   {currentItem.snippet.channelTitle}
                 </p>
               </div>
             )}
           </div>
 
-          <div className="flex items-center space-x-4">
-            <span className="text-white text-sm">
+          <div className="flex items-center gap-3 sm:gap-4">
+            <span className="hidden font-mono text-xs uppercase tracking-[0.18em] text-amber-100/60 sm:inline">
               {currentIndex + 1} of {playlistItems.length}
             </span>
             <button
@@ -432,34 +437,34 @@ export default function WatchPage() {
               role="switch"
               aria-checked={autoplayEnabled}
               onClick={() => setAutoplayEnabled((prev) => !prev)}
-              className="flex items-center space-x-2 text-white text-xs sm:text-sm hover:text-gray-200 transition-colors"
+              className="flex items-center gap-2 text-xs text-stone-300 transition hover:text-stone-50 sm:text-sm"
               title="Toggle autoplay"
             >
               <span className="hidden sm:inline">Autoplay</span>
               <span
-                className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
-                  autoplayEnabled ? 'bg-white' : 'bg-gray-600'
+                className={`relative inline-flex h-5 w-9 items-center rounded-full border transition-colors ${
+                  autoplayEnabled
+                    ? 'border-amber-200/30 bg-amber-300/30'
+                    : 'border-white/10 bg-white/[0.06]'
                 }`}
               >
                 <span
-                  className={`inline-block h-4 w-4 transform rounded-full bg-black transition-transform ${
+                  className={`inline-block h-4 w-4 transform rounded-full bg-stone-100 transition-transform ${
                     autoplayEnabled ? 'translate-x-4' : 'translate-x-1'
                   }`}
                 />
               </span>
             </button>
-            <div className="text-white text-xs opacity-70">
-              <span className="hidden sm:inline">
-                ← → to navigate, Esc to exit
-              </span>
+            <div className="hidden text-xs text-stone-500 lg:block">
+              ← → navigate · Esc exit
             </div>
           </div>
         </div>
       </div>
 
       {/* Video player */}
-      <div className="flex justify-center items-center min-h-screen">
-        <div className="w-full max-w-6xl">
+      <div className="relative z-0 flex min-h-screen items-center justify-center px-5 py-28 sm:px-8">
+        <div className="w-full max-w-6xl overflow-hidden rounded-[2rem] border border-white/10 bg-[#10100d]/90 p-2 shadow-2xl shadow-black/50">
           <YouTubePlayer
             videoId={videoId}
             autoPlay={autoplayEnabled}
@@ -488,15 +493,15 @@ export default function WatchPage() {
       </div>
 
       {/* Navigation controls */}
-      <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 z-10">
-        <div className="flex items-center space-x-4 bg-black bg-opacity-50 backdrop-blur-sm rounded-full px-6 py-3">
+      <div className="absolute bottom-8 left-1/2 z-10 -translate-x-1/2 transform">
+        <div className="flex items-center gap-4 rounded-full border border-white/10 bg-[#10100d]/85 px-5 py-3 shadow-2xl shadow-black/40 backdrop-blur-xl">
           <button
             onClick={goToPrevious}
             disabled={!hasPrevious}
-            className={`p-2 rounded-full transition-colors ${
+            className={`rounded-full p-2 transition ${
               hasPrevious
-                ? 'text-white hover:bg-white hover:text-black'
-                : 'text-gray-500 cursor-not-allowed'
+                ? 'text-stone-100 hover:bg-white hover:text-stone-950'
+                : 'cursor-not-allowed text-stone-600'
             }`}
             title="Previous video"
           >
@@ -515,17 +520,17 @@ export default function WatchPage() {
             </svg>
           </button>
 
-          <div className="text-white text-sm">
+          <div className="font-mono text-sm text-stone-300">
             {currentIndex + 1} / {playlistItems.length}
           </div>
 
           <button
             onClick={goToNext}
             disabled={!hasNext}
-            className={`p-2 rounded-full transition-colors ${
+            className={`rounded-full p-2 transition ${
               hasNext
-                ? 'text-white hover:bg-white hover:text-black'
-                : 'text-gray-500 cursor-not-allowed'
+                ? 'text-stone-100 hover:bg-white hover:text-stone-950'
+                : 'cursor-not-allowed text-stone-600'
             }`}
             title="Next video"
           >
@@ -549,7 +554,7 @@ export default function WatchPage() {
       {/* Interval Toggle Button */}
       <button
         onClick={() => setShowIntervalPanel(!showIntervalPanel)}
-        className="fixed top-20 right-4 z-30 p-3 bg-blue-600 hover:bg-blue-700 text-white rounded-full shadow-lg transition-colors"
+        className="fixed right-5 top-24 z-30 rounded-full border border-amber-200/25 bg-amber-300/15 p-3 text-amber-100 shadow-2xl shadow-black/40 transition hover:bg-amber-300/20"
         title="Manage time intervals"
       >
         <svg

--- a/src/components/IntervalManager.tsx
+++ b/src/components/IntervalManager.tsx
@@ -183,17 +183,19 @@ export function IntervalManager({
     <>
       {/* Side Panel */}
       <div
-        className={`fixed top-0 right-0 h-full w-full max-w-md bg-gray-900 text-white shadow-2xl z-50 transform transition-transform duration-300 ease-in-out ${
+        className={`fixed top-0 right-0 h-full w-full max-w-md border-l border-white/10 bg-[#10100d]/95 text-stone-100 shadow-2xl shadow-black/50 z-50 transform transition-transform duration-300 ease-in-out backdrop-blur-xl ${
           isOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
       >
         <div className="flex flex-col h-full">
           {/* Header */}
-          <div className="flex items-center justify-between p-6 border-b border-gray-700">
-            <h2 className="text-xl font-semibold">Time Intervals</h2>
+          <div className="flex items-center justify-between p-6 border-b border-white/[0.06]">
+            <h2 className="text-xl font-medium tracking-[-0.03em] text-stone-50">
+              Time Intervals
+            </h2>
             <button
               onClick={onClose}
-              className="p-2 hover:bg-gray-800 rounded-full transition-colors"
+              className="p-2 rounded-full border border-white/10 bg-white/[0.03] text-stone-300 transition hover:bg-white/[0.06] hover:text-stone-50"
               aria-label="Close panel"
             >
               <svg
@@ -215,21 +217,23 @@ export function IntervalManager({
           {/* Content */}
           <div className="flex-1 overflow-y-auto p-6 space-y-6">
             {/* Loop Toggle */}
-            <div className="flex items-center justify-between p-4 bg-gray-800 rounded-lg">
+            <div className="flex items-center justify-between p-4 rounded-2xl border border-white/10 bg-white/[0.035]">
               <div>
-                <h3 className="font-medium">Loop Intervals</h3>
-                <p className="text-sm text-gray-400">
+                <h3 className="font-medium text-stone-100">Loop Intervals</h3>
+                <p className="text-sm text-stone-400">
                   Repeat intervals continuously
                 </p>
               </div>
               <button
                 onClick={() => onToggleLoop(!loopEnabled)}
                 className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                  loopEnabled ? 'bg-blue-600' : 'bg-gray-600'
+                  loopEnabled
+                    ? 'bg-amber-300/30 ring-1 ring-amber-200/30'
+                    : 'bg-white/[0.06] ring-1 ring-white/10'
                 }`}
               >
                 <span
-                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                  className={`inline-block h-4 w-4 transform rounded-full bg-stone-100 transition-transform ${
                     loopEnabled ? 'translate-x-6' : 'translate-x-1'
                   }`}
                 />
@@ -238,29 +242,31 @@ export function IntervalManager({
 
             {/* Import from YouTube */}
             {onImportFromYouTube && (
-              <div className="p-4 bg-gray-800 rounded-lg space-y-3">
+              <div className="p-4 rounded-2xl border border-white/10 bg-white/[0.035] space-y-3">
                 <div className="flex items-center justify-between">
                   <div>
-                    <h3 className="font-medium">Import from YouTube</h3>
-                    <p className="text-sm text-gray-400">
+                    <h3 className="font-medium text-stone-100">
+                      Import from YouTube
+                    </h3>
+                    <p className="text-sm text-stone-400">
                       Use chapter timestamps from the video description
                     </p>
                   </div>
                   <button
                     onClick={handleImport}
                     disabled={isImporting}
-                    className="px-3 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 disabled:cursor-not-allowed rounded text-sm font-medium transition-colors"
+                    className="rounded-full bg-stone-100 px-4 py-2 text-sm font-medium text-stone-950 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-60"
                   >
                     {isImporting ? 'Importing...' : 'Import'}
                   </button>
                 </div>
                 {importError && (
-                  <div className="p-3 bg-red-900 bg-opacity-30 border border-red-500 rounded text-sm text-red-200">
+                  <div className="rounded-2xl border border-red-300/20 bg-red-300/10 p-3 text-sm text-red-100">
                     {importError}
                   </div>
                 )}
                 {importMessage && (
-                  <div className="p-3 bg-green-900 bg-opacity-30 border border-green-500 rounded text-sm text-green-200">
+                  <div className="rounded-2xl border border-emerald-300/20 bg-emerald-300/10 p-3 text-sm text-emerald-100">
                     {importMessage}
                   </div>
                 )}
@@ -272,14 +278,14 @@ export function IntervalManager({
               <div className="flex items-center justify-between mb-3">
                 <h3 className="font-medium">Your Intervals</h3>
                 {intervals.length > 0 && (
-                  <span className="text-sm text-gray-400">
+                  <span className="text-sm text-stone-400">
                     Total: {formatTime(totalWatchTime)}
                   </span>
                 )}
               </div>
 
               {intervals.length === 0 ? (
-                <div className="text-center py-8 text-gray-400">
+                <div className="text-center py-8 text-stone-400">
                   <p className="mb-2">No intervals yet</p>
                   <p className="text-sm">Add your first interval below</p>
                 </div>
@@ -299,14 +305,14 @@ export function IntervalManager({
                       }}
                       className={`flex items-center justify-between p-3 rounded-lg transition-colors ${
                         interval.id === activeIntervalId
-                          ? 'bg-blue-700'
-                          : 'bg-gray-800 hover:bg-gray-750'
+                          ? 'bg-amber-300/15 ring-1 ring-amber-200/25'
+                          : 'bg-white/[0.035] hover:bg-white/[0.06]'
                       } ${onSelectInterval ? 'cursor-pointer' : ''}`}
                       role={onSelectInterval ? 'button' : undefined}
                       tabIndex={onSelectInterval ? 0 : undefined}
                     >
                       <div className="flex min-w-0 flex-1 items-center space-x-3">
-                        <span className="text-sm text-gray-400">
+                        <span className="text-sm text-stone-400">
                           #{index + 1}
                         </span>
                         <div className="min-w-0 flex-1">
@@ -332,7 +338,7 @@ export function IntervalManager({
                                   }
                                 }}
                                 maxLength={100}
-                                className="min-w-0 flex-1 rounded border border-gray-600 bg-gray-900 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none"
+                                className="min-w-0 flex-1 rounded-full border border-white/10 bg-[#080806] px-3 py-1 text-sm text-stone-100 outline-none focus:border-amber-200/40"
                                 aria-label="Interval name"
                                 autoFocus
                               />
@@ -340,7 +346,7 @@ export function IntervalManager({
                                 type="button"
                                 onClick={() => saveRename(interval.id)}
                                 disabled={isRenaming}
-                                className="rounded bg-blue-600 px-2 py-1 text-xs font-medium hover:bg-blue-700 disabled:bg-gray-600"
+                                className="rounded-full bg-stone-100 px-3 py-1 text-xs font-medium text-stone-950 hover:bg-white disabled:opacity-60"
                               >
                                 Save
                               </button>
@@ -348,7 +354,7 @@ export function IntervalManager({
                                 type="button"
                                 onClick={cancelRename}
                                 disabled={isRenaming}
-                                className="rounded bg-gray-700 px-2 py-1 text-xs font-medium hover:bg-gray-600 disabled:bg-gray-600"
+                                className="rounded-full border border-white/10 bg-white/[0.035] px-3 py-1 text-xs font-medium text-stone-300 hover:bg-white/[0.06] disabled:opacity-60"
                               >
                                 Cancel
                               </button>
@@ -364,7 +370,7 @@ export function IntervalManager({
                                   event.stopPropagation();
                                   beginRename(interval, index);
                                 }}
-                                className="rounded px-2 py-0.5 text-xs text-blue-300 hover:bg-blue-600 hover:bg-opacity-20"
+                                className="rounded-full px-2 py-0.5 text-xs text-amber-100 hover:bg-amber-300/10"
                                 aria-label={`Rename ${getIntervalDisplayName(
                                   interval,
                                   index
@@ -378,7 +384,7 @@ export function IntervalManager({
                             {formatTime(interval.startTime)} →{' '}
                             {formatTime(interval.endTime)}
                           </div>
-                          <div className="text-xs text-gray-400">
+                          <div className="text-xs text-stone-500">
                             Duration:{' '}
                             {formatTime(interval.endTime - interval.startTime)}
                           </div>
@@ -389,11 +395,11 @@ export function IntervalManager({
                           event.stopPropagation();
                           handleDelete(interval.id);
                         }}
-                        className="p-2 hover:bg-red-600 hover:bg-opacity-20 rounded transition-colors"
+                        className="p-2 rounded-full transition hover:bg-red-300/10"
                         aria-label="Delete interval"
                       >
                         <svg
-                          className="w-5 h-5 text-red-400"
+                          className="w-5 h-5 text-red-200"
                           fill="none"
                           stroke="currentColor"
                           viewBox="0 0 24 24"
@@ -413,11 +419,13 @@ export function IntervalManager({
             </div>
 
             {/* Add Interval Form */}
-            <div className="border-t border-gray-700 pt-6">
-              <h3 className="font-medium mb-4">Add New Interval</h3>
+            <div className="border-t border-white/[0.06] pt-6">
+              <h3 className="font-medium mb-4 text-stone-100">
+                Add New Interval
+              </h3>
 
               {error && (
-                <div className="mb-4 p-3 bg-red-900 bg-opacity-30 border border-red-500 rounded text-sm text-red-200">
+                <div className="mb-4 rounded-2xl border border-red-300/20 bg-red-300/10 p-3 text-sm text-red-100">
                   {error}
                 </div>
               )}
@@ -429,7 +437,7 @@ export function IntervalManager({
                     <label className="text-sm font-medium">Start Time</label>
                     <button
                       onClick={() => handleUseCurrentTime('start')}
-                      className="text-xs text-blue-400 hover:text-blue-300"
+                      className="text-xs text-amber-100/80 hover:text-amber-100"
                     >
                       Use current time ({formatTime(currentTime)})
                     </button>
@@ -441,9 +449,9 @@ export function IntervalManager({
                       placeholder="MM"
                       value={startMinutes}
                       onChange={(e) => setStartMinutes(e.target.value)}
-                      className="w-20 px-3 py-2 bg-gray-800 border border-gray-600 rounded focus:outline-none focus:border-blue-500"
+                      className="w-20 rounded-full border border-white/10 bg-white/[0.035] px-3 py-2 text-stone-100 outline-none focus:border-amber-200/40"
                     />
-                    <span className="text-gray-400">:</span>
+                    <span className="text-stone-500">:</span>
                     <input
                       type="number"
                       min="0"
@@ -451,7 +459,7 @@ export function IntervalManager({
                       placeholder="SS"
                       value={startSeconds}
                       onChange={(e) => setStartSeconds(e.target.value)}
-                      className="w-20 px-3 py-2 bg-gray-800 border border-gray-600 rounded focus:outline-none focus:border-blue-500"
+                      className="w-20 rounded-full border border-white/10 bg-white/[0.035] px-3 py-2 text-stone-100 outline-none focus:border-amber-200/40"
                     />
                   </div>
                 </div>
@@ -462,7 +470,7 @@ export function IntervalManager({
                     <label className="text-sm font-medium">End Time</label>
                     <button
                       onClick={() => handleUseCurrentTime('end')}
-                      className="text-xs text-blue-400 hover:text-blue-300"
+                      className="text-xs text-amber-100/80 hover:text-amber-100"
                     >
                       Use current time ({formatTime(currentTime)})
                     </button>
@@ -474,9 +482,9 @@ export function IntervalManager({
                       placeholder="MM"
                       value={endMinutes}
                       onChange={(e) => setEndMinutes(e.target.value)}
-                      className="w-20 px-3 py-2 bg-gray-800 border border-gray-600 rounded focus:outline-none focus:border-blue-500"
+                      className="w-20 rounded-full border border-white/10 bg-white/[0.035] px-3 py-2 text-stone-100 outline-none focus:border-amber-200/40"
                     />
-                    <span className="text-gray-400">:</span>
+                    <span className="text-stone-500">:</span>
                     <input
                       type="number"
                       min="0"
@@ -484,7 +492,7 @@ export function IntervalManager({
                       placeholder="SS"
                       value={endSeconds}
                       onChange={(e) => setEndSeconds(e.target.value)}
-                      className="w-20 px-3 py-2 bg-gray-800 border border-gray-600 rounded focus:outline-none focus:border-blue-500"
+                      className="w-20 rounded-full border border-white/10 bg-white/[0.035] px-3 py-2 text-stone-100 outline-none focus:border-amber-200/40"
                     />
                   </div>
                 </div>
@@ -493,7 +501,7 @@ export function IntervalManager({
                 <button
                   onClick={handleAddInterval}
                   disabled={isAdding}
-                  className="w-full py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 disabled:cursor-not-allowed rounded-lg font-medium transition-colors"
+                  className="w-full rounded-full bg-stone-100 py-3 font-medium text-stone-950 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   {isAdding ? 'Adding...' : 'Add Interval'}
                 </button>

--- a/src/components/YouTubePlayer.tsx
+++ b/src/components/YouTubePlayer.tsx
@@ -322,9 +322,9 @@ export function YouTubePlayer({
         className="absolute top-0 left-0 w-full h-full"
       />
       {!isPlayerReady && (
-        <div className="absolute inset-0 flex items-center justify-center bg-gray-900">
-          <div className="text-white text-center">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-white mx-auto mb-4"></div>
+        <div className="absolute inset-0 flex items-center justify-center bg-[#10100d]">
+          <div className="text-center text-stone-100">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-amber-200 mx-auto mb-4"></div>
             <p>Loading video...</p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Restyles dashboard, playlist detail, and watch/player screens to match the landing page's dark stone/amber visual system
- Updates the interval manager and video loading state so player controls no longer fall back to blue/gray UI
- Removes the global white input override so authenticated dark inputs and autofill stay on-theme

## Test Plan
- npm run type-check
- npm run lint (passes with existing warnings for unused setVideoDuration and videoId)
- npx prettier --check src/app/dashboard/page.tsx src/app/p/[playlistId]/page.tsx src/app/watch/[videoId]/page.tsx src/components/IntervalManager.tsx src/components/YouTubePlayer.tsx src/app/globals.css
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy GOOGLE_CLIENT_ID=dummy GOOGLE_CLIENT_SECRET=*** NEXTAUTH_SECRET=*** NEXTAUTH_URL=http://localhost:3000 npm run build