### PR TITLE
Interval play-through on click, non-disruptive save

### DIFF
--- a/src/app/watch/[videoId]/page.tsx
+++ b/src/app/watch/[videoId]/page.tsx
@@ -102,6 +102,9 @@ export default function WatchPage() {
     time: number;
     token: number;
   } | null>(null);
+  const [playThrough, setPlayThrough] = useState<{ startIndex: number } | null>(
+    null
+  );
   const [isImportingIntervals, setIsImportingIntervals] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
   const [importMessage, setImportMessage] = useState<string | null>(null);
@@ -312,6 +315,12 @@ export default function WatchPage() {
     }
   }, [playlistItems, videoId]);
 
+  // Reset play-through when the video changes so a stale interval index from a
+  // previous video can't constrain playback of the new one.
+  useEffect(() => {
+    setPlayThrough(null);
+  }, [videoId]);
+
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -488,6 +497,8 @@ export default function WatchPage() {
             seekToSeconds={seekRequest?.time ?? null}
             seekToToken={seekRequest?.token}
             onSeekComplete={() => setSeekRequest(null)}
+            playThroughIntervals={playThrough !== null}
+            playThroughStartIndex={playThrough?.startIndex ?? 0}
           />
         </div>
       </div>
@@ -582,15 +593,24 @@ export default function WatchPage() {
         onAddInterval={handleAddInterval}
         onDeleteInterval={handleDeleteInterval}
         onRenameInterval={handleRenameInterval}
-        onToggleLoop={setLoopEnabled}
+        onToggleLoop={(enabled) => {
+          // Toggling loop exits any active play-through so loop mode regains
+          // control of playback.
+          setPlayThrough(null);
+          setLoopEnabled(enabled);
+        }}
         onImportFromYouTube={handleImportFromYouTube}
         isImporting={isImportingIntervals}
         importError={importError}
         importMessage={importMessage}
         activeIntervalId={activeIntervalId}
-        onSelectInterval={(interval) =>
-          setSeekRequest({ time: interval.startTime, token: Date.now() })
-        }
+        onSelectInterval={(interval) => {
+          const startIndex = sortedIntervals.findIndex(
+            (item) => item.id === interval.id
+          );
+          setPlayThrough({ startIndex: startIndex >= 0 ? startIndex : 0 });
+          setSeekRequest({ time: interval.startTime, token: Date.now() });
+        }}
         isOpen={showIntervalPanel}
         onClose={() => setShowIntervalPanel(false)}
       />

--- a/src/components/YouTubePlayer.tsx
+++ b/src/components/YouTubePlayer.tsx
@@ -79,6 +79,8 @@ interface YouTubePlayerProps {
   seekToSeconds?: number | null;
   seekToToken?: number;
   onSeekComplete?: () => void;
+  playThroughIntervals?: boolean;
+  playThroughStartIndex?: number;
 }
 
 export function YouTubePlayer({
@@ -95,6 +97,8 @@ export function YouTubePlayer({
   seekToSeconds = null,
   seekToToken,
   onSeekComplete,
+  playThroughIntervals = false,
+  playThroughStartIndex = 0,
 }: YouTubePlayerProps) {
   const playerRef = useRef<YouTubePlayerInstance | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -110,6 +114,11 @@ export function YouTubePlayer({
   // Interval playback state
   const [currentIntervalIndex, setCurrentIntervalIndex] = useState(0);
   const intervalCheckRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Tracks the interval currently being played through after an explicit
+  // user click. Once it advances past the last interval the value equals the
+  // interval count, which signals that normal playback should resume.
+  const playThroughIndexRef = useRef(0);
 
   useEffect(() => {
     // Load YouTube IFrame API
@@ -205,8 +214,22 @@ export function YouTubePlayer({
 
     playerRef.current.seekTo(seekToSeconds, true);
     playerRef.current.playVideo();
+
+    // An explicit interval click seeks the player; start the play-through
+    // sequence from the clicked interval so subsequent intervals follow.
+    if (playThroughIntervals) {
+      playThroughIndexRef.current = playThroughStartIndex;
+    }
+
     onSeekComplete?.();
-  }, [isPlayerReady, seekToSeconds, seekToToken, onSeekComplete]);
+  }, [
+    isPlayerReady,
+    seekToSeconds,
+    seekToToken,
+    onSeekComplete,
+    playThroughIntervals,
+    playThroughStartIndex,
+  ]);
 
   // Current-time + interval playback monitoring
   useEffect(() => {
@@ -240,6 +263,57 @@ export function YouTubePlayer({
 
         // Only apply interval playback behavior when playing
         if (playerState !== window.YT.PlayerState.PLAYING) return;
+
+        // Play-through mode: the user explicitly clicked an interval. Play the
+        // current interval, then automatically advance to each subsequent
+        // interval in order. After the final interval finishes, stop
+        // constraining playback so the rest of the video plays normally.
+        if (playThroughIntervals) {
+          const activeIndex = playThroughIndexRef.current;
+
+          // Sequence already completed: let the video play to the end.
+          if (activeIndex >= sortedIntervals.length) return;
+
+          const activeInterval = sortedIntervals[activeIndex];
+
+          if (currentTime >= activeInterval.endTime) {
+            const nextIndex = activeIndex + 1;
+            if (nextIndex < sortedIntervals.length) {
+              playerRef.current.seekTo(
+                sortedIntervals[nextIndex].startTime,
+                true
+              );
+              playThroughIndexRef.current = nextIndex;
+              setCurrentIntervalIndex(nextIndex);
+              onIntervalChange?.(nextIndex);
+            } else {
+              // Past the final interval: resume normal playback.
+              playThroughIndexRef.current = sortedIntervals.length;
+            }
+          } else if (activeIndex !== currentIntervalIndex) {
+            setCurrentIntervalIndex(activeIndex);
+            onIntervalChange?.(activeIndex);
+          }
+          return;
+        }
+
+        // Without loop or play-through, leave playback untouched and only keep
+        // the active interval highlight in sync as the video plays.
+        if (!loopEnabled) {
+          const containingIndex = sortedIntervals.findIndex(
+            (interval) =>
+              currentTime >= interval.startTime &&
+              currentTime < interval.endTime
+          );
+          if (
+            containingIndex !== -1 &&
+            containingIndex !== currentIntervalIndex
+          ) {
+            setCurrentIntervalIndex(containingIndex);
+            onIntervalChange?.(containingIndex);
+          }
+          return;
+        }
 
         // Find which interval we should be in
         let targetIntervalIndex = -1;
@@ -312,6 +386,7 @@ export function YouTubePlayer({
     currentIntervalIndex,
     onIntervalChange,
     onCurrentTimeUpdate,
+    playThroughIntervals,
   ]);
 
   return (


### PR DESCRIPTION
## Summary

Changes the interval playback behavior in the watch page:

1. **Saving an interval no longer disrupts playback** — the video continues playing in the background when the user adds a new interval.

2. **Clicking an interval seeks to its start and plays** — clicking an interval in the list seeks the video to that interval's start time and begins playing.

3. **Sequential interval play-through** — after clicking an interval, the video plays through it, then automatically advances to the next interval in order. After the last interval finishes, the video continues playing normally to the end (no looping, no pausing).

## Files changed
- `src/components/YouTubePlayer.tsx` — added `playThroughIntervals` and `playThroughStartIndex` props; new play-through mode in the monitoring loop
- `src/app/watch/[videoId]/page.tsx` — added `playThrough` state; `onSelectInterval` now triggers sequential play-through; loop toggle clears play-through; resets on video change

## Verification
- npm run type-check passed
- npm run build passed